### PR TITLE
Fix class javadoc merging

### DIFF
--- a/spec/src/main/java/net/neoforged/javadoctor/spec/ClassJavadoc.java
+++ b/spec/src/main/java/net/neoforged/javadoctor/spec/ClassJavadoc.java
@@ -50,7 +50,7 @@ public final class ClassJavadoc {
     public ClassJavadoc merge(@Nullable ClassJavadoc other) {
         if (other == null) return this;
         return new ClassJavadoc(
-                clazz == null ? other.clazz : other.clazz == null ? clazz : clazz.merge(other.clazz),
+                clazz == null ? other.clazz : clazz.merge(other.clazz),
                 mergeMaps(JavadocEntry::merge, this.methods, other.methods),
                 mergeMaps(JavadocEntry::merge, this.fields, other.fields),
                 mergeMaps(ClassJavadoc::merge, this.innerClasses, other.innerClasses)

--- a/spec/src/main/java/net/neoforged/javadoctor/spec/ClassJavadoc.java
+++ b/spec/src/main/java/net/neoforged/javadoctor/spec/ClassJavadoc.java
@@ -50,7 +50,7 @@ public final class ClassJavadoc {
     public ClassJavadoc merge(@Nullable ClassJavadoc other) {
         if (other == null) return this;
         return new ClassJavadoc(
-                clazz == null ? other.clazz : clazz,
+                clazz == null ? other.clazz : other.clazz == null ? clazz : clazz.merge(other.clazz),
                 mergeMaps(JavadocEntry::merge, this.methods, other.methods),
                 mergeMaps(JavadocEntry::merge, this.fields, other.fields),
                 mergeMaps(ClassJavadoc::merge, this.innerClasses, other.innerClasses)

--- a/spec/src/main/java/net/neoforged/javadoctor/spec/JavadocEntry.java
+++ b/spec/src/main/java/net/neoforged/javadoctor/spec/JavadocEntry.java
@@ -42,7 +42,10 @@ public final class JavadocEntry {
         return typeParameters;
     }
 
-    public JavadocEntry merge(JavadocEntry other) {
+    public JavadocEntry merge(@Nullable JavadocEntry other) {
+        if (other == null) {
+            return this;
+        }
         return new JavadocEntry(
                 doc == null ? other.doc : doc,
                 ClassJavadoc.mergeMaps(ClassJavadoc::mergeLists, this.tags, other.tags),


### PR DESCRIPTION
Fixes class javadoc merging simply picking the first non-null javadoc entry