### PR TITLE
Fix multi-line formatting of javadoc tags

### DIFF
--- a/collector/src/main/java/net/neoforged/javadoctor/collector/JavadocCollector.java
+++ b/collector/src/main/java/net/neoforged/javadoctor/collector/JavadocCollector.java
@@ -251,7 +251,7 @@ public class JavadocCollector {
             }
 
             if ((line.isEmpty() || line.charAt(0) == ' ') && tagName != null) {
-                current.append(line.trim());
+                current.append(' ').append(line.trim());
             } else {
                 if (tagName != null) {
                     walker.onTag(tagName, current.toString().trim());

--- a/test/src/main/java/mixins/InsertTest.java
+++ b/test/src/main/java/mixins/InsertTest.java
@@ -10,8 +10,8 @@ class InsertTest {
 
     static class Inner1 {
         static class Inner2 {
-            int weirdNr2(AtomicInteger integer) {
-                return integer.get();
+            int weirdNr2(AtomicInteger integer, int replacement) {
+                return integer.getAndSet(replacement);
             }
         }
     }

--- a/test/src/main/java/mixins/InsertTestMixin.java
+++ b/test/src/main/java/mixins/InsertTestMixin.java
@@ -24,9 +24,11 @@ abstract class InsertTestMixin {
 abstract class Inner2Mixin {
     /**
      * Soo... this returns stuff from the {@code integer} of type {@link AtomicInteger}.
-     * @param integer the param
+     * @param integer the param with very much text that goes on and on for a very long time because the goal is to hopefully trick it into forcing a
+     *                multiline tag
+     * @param replacement and now we're going to see how it handles multiple parameters
      * @return the returned magic thingy
      */
     @Shadow
-    abstract int weirdNr2(AtomicInteger integer);
+    abstract int weirdNr2(AtomicInteger integer, int replacement);
 }


### PR DESCRIPTION
This PR fixes some quirks of multi-line javadocs' formatting, and some weirdness with how parameter javadocs are formatted.